### PR TITLE
Checkbox labels accessibility

### DIFF
--- a/src/WPBT_Settings.php
+++ b/src/WPBT_Settings.php
@@ -270,7 +270,7 @@ class WPBT_Settings {
 		?>
 		<style> .form-table th { display:none; } </style>
 		<label for="<?php esc_attr_e( $args['id'] ); ?>">
-			<input type="checkbox" name="wp-beta-tester[<?php esc_attr_e( $args['id'] ); ?>]" value="1" <?php checked( '1', $checked ); ?> >
+			<input type="checkbox" id="<?php esc_attr_e( $args['id'] ); ?>" name="wp-beta-tester[<?php esc_attr_e( $args['id'] ); ?>]" value="1" <?php checked( '1', $checked ); ?> >
 			<?php esc_attr_e( $args['title'] ); ?>
 		</label>
 		<?php


### PR DESCRIPTION
Hi,

Label should match the id attribute of the checkbox, not their name.

I replaced 
```
		<label for="<?php esc_attr_e( $args['id'] ); ?>">
			<input type="checkbox" name="wp-beta-tester[<?php esc_attr_e( $args['id'] ); ?>]" value="1" <?php checked( '1', $checked ); ?> >
			<?php esc_attr_e( $args['title'] ); ?>
		</label>
```
with
```
		<label for="<?php esc_attr_e( $args['id'] ); ?>">
			<input type="checkbox" id="<?php esc_attr_e( $args['id'] ); ?>" name="wp-beta-tester[<?php esc_attr_e( $args['id'] ); ?>]" value="1" <?php checked( '1', $checked ); ?> >
			<?php esc_attr_e( $args['title'] ); ?>
		</label>
```
Cheers,
Jb