### PR TITLE
Allow Beta Tester to update to beta/RC packages

### DIFF
--- a/src/WPBT/WPBT_Beta_RC.php
+++ b/src/WPBT/WPBT_Beta_RC.php
@@ -1,53 +1,23 @@
 <?php
 
 /**
- * Description: Limit core updates to next Beta/RC release if currently running a Beta/RC release
- * Version: 0.1.0
  * Author: Paul V. Biron/Sparrow Hawk Computing
- * Author URI: https://sparrowhawkcomputing.com
- * Plugin URI: https://github.com/pbiron/shc-wordpress-beta-tester
- * GitHub Plugin URI: https://github.com/pbiron/shc-wordpress-beta-tester
- * Network: true
- * License: GPLv2 or later
- * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Author Email: paul@sparrowhawkcomputing.com
+ * Author URL: https://sparrowhawkcomputing.com
  */
-
-// namespace SHC\WordPress_Beta_Tester;
 
 defined( 'ABSPATH' ) || die;
 
-global $wp_version;
-if ( ! preg_match( '@' . WPBT_Beta_RC::$beta_rc_version_regex . '@', $wp_version ) ) {
-	// site is not running a "named" beta/RC release.
-	// nothing to do, so bail (essentially, we'll be a no-op plugin in this case).
+$options = get_site_option( 'wp_beta_tester', array( 'stream' => 'point' ) );
+if ( 0 !== strpos( $options['stream'], 'beta-rc' ) ) {
+	// not on the beta-rc stream.
+	// nothing to do, so bail (essentially, we'll be back to stock beta-tester behavior).
 	return;
 }
 
 /**
- * Class to modify the response to the Core Update API.
- *
- * Ideally, these mods would be part of the Core Update API, but since that is not
- * open-sourced, it likely would be hard (i.e., take a long time) for whoever controls
- * that API to incorportate these mods.
- *
- * Since this class will not be instantiated if the current site is not
- * running a "named" beta/RC release, we don't need to check that in any
- * of the methods here.
- *
- * My immediate use-case for this functionality is as follows:
- *
- * 1. once I install beta1 on a site, I want to continue to test *that* version
- *    and not worry about things working differently tomorrow after additional commits
- *    have been made to trunk.  For instance, if I find something that doesn't work
- *    correctly in beta1 but don't have time to immediately investigate exactly why,
- *    I don't want the site to get updated to the next nightly...as that might change
- *    the behavior that I identified.
- *
- * However, it might be useful to use this prototype to investigate how those API mods
- * would work.  For that purpose, the logic of when to test for the next beta/RC package would
- * have to change a little.  For instance, suppose the site is running 5.4-alpha-12345,
- * then the "next" package would be 5.4-beta1.  I don't think that change would be
- * too hard.  Also, see the "@todo" in update_to_beta_or_rc_releases().
+ * Class to modify the response to the Core Update API to include the next beta/RC
+ * package if it is available.
  *
  * @since 0.1.0
  */
@@ -57,15 +27,12 @@ class WPBT_Beta_RC {
 	 *
 	 * The subpatterns are as follows:
 	 *
-	 * 1. The first is the WP version number (e.g., 5.2.3).
-	 * 2. The second is the minor version number (e.g., .3 in the above example).
+	 * 1. The first is the WP version number (e.g., 5.2).
+	 * 2. The second is the minor version number (e.g., .3).
 	 *    This subpattern is optional because WP uses versions numbers like
 	 *    5.3 instead of 5.3.0.
-	 * 3. The third is whether the release is a beta or RC.
+	 * 3. The third is whether the release is an alpha, beta or RC.
 	 * 4. The forth is the number of the beta or RC release (e.g., 1st beta, 2nd RC, etc).
-	 *
-	 * If a `$wp_version` string does not match this regex, then the site is
-	 * not running a beta/RC release.
 	 *
 	 * We store this regex as a static property because we use it in 2 separate places
 	 * and doing so ensures that the regex is the same in both places.
@@ -74,7 +41,7 @@ class WPBT_Beta_RC {
 	 *
 	 * @var string
 	 */
-	static $beta_rc_version_regex = '^(\d+\.\d+(\.\d+)?)-(beta|RC)(\d+)$';
+	static $version_regex = '^(\d+\.\d+(\.\d+)?)-(alpha|beta|RC)(\d+|\d*-\d+)?$';
 
 	/**
 	 * Used to store the URL(s) for the next beta/RC download packages.
@@ -84,6 +51,15 @@ class WPBT_Beta_RC {
 	 * @var array
 	 */
 	protected $next_package_urls = array();
+
+	/**
+	 * Whether we found the next beta/RC package.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @var bool
+	 */
+	protected $found = false;
 
 	/**
 	 * Constructor.
@@ -101,27 +77,46 @@ class WPBT_Beta_RC {
 		global $wp_version;
 
 		add_filter( 'http_response', array( $this, 'update_to_beta_or_rc_releases' ), 10, 3 );
+		// set priority to 11 so that we fire after the function core hooks into this filter.
+		add_filter( 'update_footer', array( $this, 'update_footer' ), 11 );
 
+		// beta/RC downloads, when available, are at a URL matching this pattern.
 		$beta_rc_download_url_pattern = 'https://wordpress.org/wordpress-%s-%s%s.zip';
 
-		// extract the parts of the beta/RC version the site is running.
+		// extract the parts of the version the site is running.
 		$matches = array();
-		preg_match( '@' . self::$beta_rc_version_regex . '@', $wp_version, $matches );
+		preg_match( '@' . self::$version_regex . '@', $wp_version, $matches );
 
-		// see the DocBlock of self::$beta_rc_version_regex for what those parts are.
+		// see the DocBlock of self::$version_regex for what those parts are.
 		$version    = $matches[1];
-		$beta_or_rc = $matches[3];
-		$next       = intval( $matches[4] ) + 1;
+
+		$package_type = $matches[3];
+		$next         = intval( $matches[4] ) + 1;
 
 		// construct the URLs for the next beta/RC release.
-		if ( 'beta' === $beta_or_rc ) {
-			// when running a beta, we check for both the next beta and the first RC.
-			// check the RC1 package first.
-			$this->next_package_urls[ "{$version}-RC1" ]         = sprintf( $beta_rc_download_url_pattern, $version, 'RC', 1 );
-			$this->next_package_urls[ "{$version}-beta{$next}" ] = sprintf( $beta_rc_download_url_pattern, $version, 'beta', $next );
-		} else {
-			// when running an RC, we just check for the next RC.
-			$this->next_package_urls[ "{$version}-RC{$next}" ] = sprintf( $beta_rc_download_url_pattern, $version, 'RC', $next );
+		switch ( $package_type ) {
+			case 'alpha':
+				// when running alpha, we check for both the first beta and the first RC.
+				// check the RC1 package first.
+				// @todo do we really want to check for RC1?  The only way it would be found
+				//       is if someone downgraded a site to an alpha after beta1 was
+				//       was released.
+				$this->next_package_urls[ "{$version}-RC1" ]   = sprintf( $beta_rc_download_url_pattern, $version, 'RC', 1 );
+				$this->next_package_urls[ "{$version}-beta1" ] = sprintf( $beta_rc_download_url_pattern, $version, 'beta', 1 );
+
+				break;
+			case 'beta':
+				// when running a beta, we check for both the next beta and the first RC.
+				// check the RC1 package first.
+				$this->next_package_urls[ "{$version}-RC1" ]         = sprintf( $beta_rc_download_url_pattern, $version, 'RC', 1 );
+				$this->next_package_urls[ "{$version}-beta{$next}" ] = sprintf( $beta_rc_download_url_pattern, $version, 'beta', $next );
+
+				break;
+			case 'RC':
+				// when running an RC, we just check for the next RC.
+				$this->next_package_urls[ "{$version}-RC{$next}" ] = sprintf( $beta_rc_download_url_pattern, $version, 'RC', $next );
+
+				break;
 		}
 
 		return;
@@ -149,12 +144,17 @@ class WPBT_Beta_RC {
 			return $response;
 		}
 
+		$options = get_site_option( 'wp_beta_tester', array( 'stream' => 'point' ) );
+		if ( 0 !== strpos( $options['stream'], 'beta-rc' ) ) {
+			return $response;
+		}
+
 		// get the response body as an array.
 		$body = json_decode( wp_remote_retrieve_body( $response ), true );
 
 		// loop through the next beta/RC download URLs and see if a package exists
 		// at any of them.
-		$found = false;
+		$this->found = false;
 		foreach ( $this->next_package_urls as $version => $next_package_url ) {
 			if ( ! $this->next_package_exists( $next_package_url ) ) {
 				continue;
@@ -180,12 +180,12 @@ class WPBT_Beta_RC {
 				}
 			}
 
-			$found = true;
+			$this->found = true;
 
 			break;
 		}
 
-		if ( ! $found ) {
+		if ( ! $this->found ) {
 			// the next beta/RC release package was not found.
 			// remove the development and autoupdate offers.
 			$body['offers'] = array_diff_key(
@@ -230,7 +230,63 @@ class WPBT_Beta_RC {
 
 		return ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response );
 	}
-}
 
-// instantiate ourself.
-// new Plugin();
+	/**
+	 * Ensure core still displays "You are using a development verison..." in the admin
+	 * footer, even if we've removed the `development` update response because the next
+	 * beta/RC package is not available.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param string $content The content that will be printed.
+	 * @return string
+	 *
+	 * @filter update_footer
+	 */
+	function update_footer( $content = '' ) {
+		if ( $this->found ) {
+			// we found the next beta/RC package, so no need to "fake" the
+			// footer message.
+			// nothing to do, so bail.
+			return $content;
+		}
+
+		add_filter( "pre_site_transient_update_core", array( $this, 'add_minimal_development_response' ), 10, 2 );
+
+		$content = core_update_footer();
+
+		remove_filter( 'pre_site_transient_update_core', array( $this, 'add_minimal_development_response' ) );
+
+		return $content;
+	}
+
+	/**
+	 * Add a minimal development response as the preferred update.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param mixed $pre_site_transient The default value to return if the site
+	 *                                  transient does not exist. Any value other
+	 *                                  than false will short-circuit the retrieval
+	 *                                  of the transient, and return the returned value.
+	 * @param string $transient 	    Transient name.
+	 * @return mixed
+	 *
+	 * @filter pre_site_transient_update_core
+	 */
+	function add_minimal_development_response( $pre_site_transient, $transient ) {
+		$from_api = new stdClass();
+		$update = new stdClass();
+		// a "minimal" response is one with the `response`, `current` and
+		// `locale` properties.
+		$update->response = 'development';
+		$update->current = get_bloginfo( 'version' );
+		$update->locale = get_locale();
+
+		$from_api->updates = array(
+			$update,
+		);
+
+		return $from_api;
+	}
+}

--- a/src/WPBT/WP_Beta_Tester.php
+++ b/src/WPBT/WP_Beta_Tester.php
@@ -41,6 +41,7 @@ class WP_Beta_Tester {
 		// TODO: I really want to do this, but have to wait for PHP 5.4
 		// ( new WPBT_Settings( $this, $options ) )->run();
 		$settings = new WPBT_Settings( $this, $options );
+		new WPBT_Beta_RC();
 		$settings->run();
 	}
 
@@ -154,7 +155,13 @@ class WP_Beta_Tester {
 			return $wp_version;
 		}
 
-		$versions = array_map( 'intval', explode( '.', $preferred->current ) );
+		if ( 0 === strpos( '/beta-rc/', $options['stream' ] ) &&
+				version_compare( $preferred->current, $wp_version, 'lt' ) ) {
+			$versions = array_map( 'intval', explode( '.', $wp_version ) );
+		}
+		else {
+			$versions = array_map( 'intval', explode( '.', $preferred->current ) );
+		}
 
 		switch ( $options['stream'] ) {
 			case 'point':


### PR DESCRIPTION
Fixes: #7 

I think this is fairly (if not completely) functional:

1. it works whether the site is running an alpha, beta/RC nightly (and has just be set to use the `beta-rc-untable` stream) or a current beta/RC package.
2. as discussed in slack, the text on the `update-core.php` screen still says "You can update to the latest nightly build automatically:" even when it will update to a beta/RC package.
3. I have *not* tested the `beta-rc-point` stream.
4. I took out the extraneous inline docs from my original plugin.  A few of the inline docs still need to be updated to reflect the current functioning.

