### PR TITLE
Improve reporting on the next version to be updated to on the setting screen when the next beta/RC package is not found.

### DIFF
--- a/src/WPBT/WPBT_Beta_RC.php
+++ b/src/WPBT/WPBT_Beta_RC.php
@@ -108,8 +108,8 @@ class WPBT_Beta_RC {
 	public function get_next_packages() {
 		$wp_version = get_bloginfo( 'version' );
 		// Exit early if not currently on a development branch.
-		if ( ! preg_match( '/alpha|beta|RC/', get_bloginfo( 'version' ) ) ) {
-			return array( esc_attr( 'next release version', 'wordpress-beta-tester' ) => false );
+		if ( ! preg_match( '/alpha|beta|RC/', $wp_version ) ) {
+			return array( __( 'next release version', 'wordpress-beta-tester' ) => false );
 		}
 
 		// beta/RC downloads, when available, are at a URL matching this pattern.

--- a/src/WPBT/WPBT_Core.php
+++ b/src/WPBT/WPBT_Core.php
@@ -125,9 +125,8 @@ class WPBT_Core {
 			echo '<p>' . wp_kses_post( __( '<strong>Please note:</strong> There are no development builds of the beta stream you have chosen available, so you will receive normal update notifications.', 'wordpress-beta-tester' ) ) . '</p>';
 			echo '</div>';
 		}
-		$next_package       = array_reverse( array_keys( $this->wp_beta_tester->next_package_urls ) );
-		$next_package       = array_pop( $next_package );
-		$preferred->version = ( 0 === strpos( static::$options['stream'], 'beta-rc' ) || ! preg_match( '/alpha|beta|RC/', get_bloginfo( 'version' ) ) ) ? $next_package : $preferred->version;
+
+		$preferred->version = $this->get_next_version( $preferred->version );
 
 		echo '<div><p>';
 		printf(
@@ -222,5 +221,40 @@ class WPBT_Core {
 			<?php endif; ?>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Get the next version the site will be updated to.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param string $preferred_version The preferred version.
+	 * @return string
+	 */
+	function get_next_version( $preferred_version ) {
+		if ( ! ( 0 === strpos( static::$options['stream'], 'beta-rc' ) ||
+				! preg_match( '/alpha|beta|RC/', get_bloginfo( 'version' ) ) ) ) {
+			// site is not running a development version or not on a beta/RC stream.
+			// So use the preferred version.
+			return $preferred_version;
+		}
+
+		$next_version = $this->wp_beta_tester->beta_rc->get_found_version();
+		if ( $next_version ) {
+			// the next beta/RC package was found, return that version.
+			return $next_version;
+		}
+
+		// the next beta/RC package was not found.
+		$next_version = $this->wp_beta_tester->beta_rc->next_package_versions();
+		if ( count( $next_version ) === 1 ) {
+			$next_version = array_shift( $next_version );
+		}
+		else {
+			// show all versions that may come next.
+			$next_version = implode( ' or ', $next_version ) . ', ' . __( 'whichever is released first', 'wordpress-beta-tester' );
+		}
+
+		return $next_version;
 	}
 }

--- a/src/WPBT/WPBT_Core.php
+++ b/src/WPBT/WPBT_Core.php
@@ -16,9 +16,16 @@ class WPBT_Core {
 	/**
 	 * Placeholder for saved options.
 	 *
-	 * @var $options
+	 * @var array
 	 */
 	protected static $options;
+
+	/**
+	 * Holds the WP_Beta_Tester instance.
+	 *
+	 * @var WP_Beta_Tester
+	 */
+	protected $wp_beta_tester;
 
 	/**
 	 * Constructor.

--- a/src/WPBT/WPBT_Core.php
+++ b/src/WPBT/WPBT_Core.php
@@ -129,7 +129,7 @@ class WPBT_Core {
 		$preferred = $this->wp_beta_tester->get_preferred_from_update_core();
 		if ( 'development' !== $preferred->response ) {
 			echo '<div class="updated fade">';
-			echo '<p>' . wp_kses_post( __( '<strong>Please note:</strong> There are no development builds of the beta stream you have chosen available, so you will receive normal update notifications.', 'wordpress-beta-tester' ) ) . '</p>';
+			echo '<p>' . wp_kses_post( __( '<strong>Please note:</strong> There are no development builds available for the beta stream you have chosen, so you will receive normal update notifications.', 'wordpress-beta-tester' ) ) . '</p>';
 			echo '</div>';
 		}
 

--- a/src/WPBT/WP_Beta_Tester.php
+++ b/src/WPBT/WP_Beta_Tester.php
@@ -21,11 +21,13 @@ class WP_Beta_Tester {
 	public $file;
 
 	/**
-	 * Holds Beta/RC next packages.
+	 * Holds Beta/RC class instance.
 	 *
-	 * @var array
+	 * @since 2.2.0
+	 *
+	 * @var WPBT_Beta_RC
 	 */
-	public $next_package_urls = array();
+	 public $beta_rc;
 
 	/**
 	 * Constructor.
@@ -49,9 +51,7 @@ class WP_Beta_Tester {
 		// TODO: ( new WPBT_Settings( $this, $options ) )->run();
 		$settings = new WPBT_Settings( $this, $options );
 		$settings->run();
-		// TODO: $this->next_package_urls = ( new WPBT_Beta_RC( $this ) )->get_next_packages();
-		$beta_rc                 = new WPBT_Beta_RC();
-		$this->next_package_urls = $beta_rc->get_next_packages();
+		$this->beta_rc = new WPBT_Beta_RC();
 	}
 
 	/**


### PR DESCRIPTION
When on a `beta-rc` stream, the site is running an `alpha` or a `beta` version and the next package is not found, this allows the settings screen to show all possible versions that will be updated to next.

It also fixes the translation bug we discussed on slack and has a string improvement for the admin notice about no builds being available for the chosen stream (sorry, probably should have done those as separate PRs).