### PR TITLE
add a sidebar to the new settings screen help tab.

### DIFF
--- a/src/WPBT/WPBT_Help.php
+++ b/src/WPBT/WPBT_Help.php
@@ -34,5 +34,10 @@ class WPBT_Help {
 				'content' => '<p>' . __( 'This screen provides help information for the Beta Tester plugin.', 'wordpress-beta-tester' ) . '</p>',
 			)
 		);
+
+		get_current_screen()->set_help_sidebar(
+			'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
+			'<p>' . __( '<a href="https://make.wordpress.org/core/handbook/testing/beta-testing/">Beta Testing</a>', 'wordpress-beta-tester' ) . '</p>'
+		);
 	}
 }


### PR DESCRIPTION
Not sure there are polyglot versions of the core handbook (linked to from the new sidebar).  If there are, then it would make sense to change how the link is created (so that translators can translate the URL separately from the link text).

I've asked in the #docs channel in Slack but haven't gotten a response yet.