### PR TITLE
`WPBT_Bug_Report::set_browser()` fixes.

### DIFF
--- a/src/WPBT/WPBT_Bug_Report.php
+++ b/src/WPBT/WPBT_Bug_Report.php
@@ -217,9 +217,13 @@ class WPBT_Bug_Report {
 	private function set_browser() {
 		global $is_lynx, $is_gecko, $is_opera, $is_NS4, $is_safari, $is_chrome, $is_IE, $is_edge;
 
-		$agent = isset( $_SERVER['HTTP_USER_AGENT'] ) && sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
-
 		self::$browser = __( 'Could not determine.', 'wordpress-beta-tester' );
+
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return;
+		}
+
+		$agent         = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
 		$browsers      = array(
 			'Lynx'              => $is_lynx,
 			'Gecko'             => $is_gecko,

--- a/src/WPBT/WPBT_Bug_Report.php
+++ b/src/WPBT/WPBT_Bug_Report.php
@@ -245,7 +245,7 @@ class WPBT_Bug_Report {
 		self::$browser = end( $browser );
 
 		// Try to get the browser version.
-		preg_match( '/' . self::$browser . '\/([0-9\.\-]+)/', $agent, $version );
+		preg_match( '/' . ( 'Edge' === self::$browser ? 'Edg' : self::$browser ) . '\/([0-9\.\-]+)/', $agent, $version );
 
 		self::$browser .= $version ? ' ' . $version[1] : '';
 		self::$browser .= wp_is_mobile() ? ' (' . __( 'Mobile', 'wordpress-beta-tester' ) . ')' : '';


### PR DESCRIPTION
This:
- Returns early when `$_SERVER['HTTP_USER_AGENT']` is empty. When the user agent isn't detectable, the browser will be shown as `Could not determine.`. This is consistent with other methods.
- Ensures that Edge version numbers are matched in the regex.