### PR TITLE
Use `trailingslashit()` instead of concatenation.

### DIFF
--- a/src/WPBT/WPBT_Bug_Report.php
+++ b/src/WPBT/WPBT_Bug_Report.php
@@ -278,7 +278,7 @@ class WPBT_Bug_Report {
 		}
 
 		foreach ( $plugin_files as $k => &$plugin ) {
-			$path    = WP_PLUGIN_DIR . '/' . $plugin;
+			$path    = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
 			$data    = get_plugin_data( $path );
 			$name    = $data['Name'];
 			$version = $data['Version'];
@@ -305,7 +305,7 @@ class WPBT_Bug_Report {
 		}
 
 		foreach ( $plugin_files as $k => &$plugin ) {
-			$path    = WP_CONTENT_DIR . '/mu-plugins/' . $k;
+			$path    = trailingslashit( WP_CONTENT_DIR ) . 'mu-plugins/' . $k;
 			$data    = get_plugin_data( $path );
 			$name    = ! empty( $data['Name'] ) ? $data['Name'] : $k;
 			$version = ! empty( $data['Version'] ) ? $data['Version'] : '';


### PR DESCRIPTION
This protects against `//` in paths, which may cause issues on some systems.