### PR TITLE
`Bug Report`: Replace `&nbsp;` with a literal space in clipboard text.

### DIFF
--- a/src/WPBT/WPBT_Bug_Report.php
+++ b/src/WPBT/WPBT_Bug_Report.php
@@ -479,7 +479,9 @@ class WPBT_Bug_Report {
 			<div style="display: flex; align-items: center; gap: 1rem;">
 				<a class="button button-small" href="<?php echo esc_url( $url ); ?>" target="_blank"><?php esc_html_e( 'File a report', 'wordpress-beta-tester' ); ?></a>
 				<div style="display: flex; align-items: center; gap: .25rem;">
-					<button type="button" class="button button-small" data-clipboard-text="<?php echo esc_attr( $test_report ); ?>"><?php esc_html_e( 'Copy to clipboard', 'wordpress-beta-tester' ); ?></button>
+					<button type="button" class="button button-small" data-clipboard-text="<?php echo esc_attr( str_replace( '&nbsp;', ' ', $test_report ) ); ?>">
+						<?php esc_html_e( 'Copy to clipboard', 'wordpress-beta-tester' ); ?>
+					</button>
 					<span class="success hidden" style="color: #008a20;" aria-hidden="true"><?php esc_html_e( 'Copied!', 'wordpress-beta-tester' ); ?></span>
 				</div>
 			</div>


### PR DESCRIPTION
Nested items don't appear in GitHub due to the `&nbsp;` running through `esc_attr()`.

This replaces `&nbsp;` with a literal space in clipboard text before running it through `esc_attr()`.