### PR TITLE
`Bug Report`: Detect `OPR` in user agent strings.

### DIFF
--- a/src/WPBT/WPBT_Bug_Report.php
+++ b/src/WPBT/WPBT_Bug_Report.php
@@ -320,7 +320,15 @@ class WPBT_Bug_Report {
 			return;
 		}
 
-		$agent    = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
+		$agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
+
+		if ( false !== strpos( $agent, 'OPR' ) ) {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$is_chrome = false;
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$is_opera = true;
+		}
+
 		$browsers = array(
 			'Lynx'              => $is_lynx,
 			'Gecko'             => $is_gecko,


### PR DESCRIPTION
WordPress Core's browser detection doesn't look for `'OPR'` inside user agent strings and only checks for `'Opera'`. While this is in the process of being fixed in WordPress Core, we can fix it in the Beta Tester plugin now.

See:
- [Support ticket](https://wordpress.org/support/topic/bug-opera-doesnt-get-correctly-recognized-as-user-agent/)
- [Trac ticket](https://core.trac.wordpress.org/ticket/46132)