### PR TITLE
Add "(or higher)" to "set to update to" RC message

### DIFF
--- a/src/WPBT/WPBT_Core.php
+++ b/src/WPBT/WPBT_Core.php
@@ -450,7 +450,7 @@ class WPBT_Core {
 		$next_versions = array(
 			'point'   => $next_point,
 			'beta'    => $exploded_version[0] . '-beta' . $next_beta,
-			'rc'      => $exploded_version[0] . '-RC' . $next_rc,
+			'rc'      => $exploded_version[0] . '-RC' . $next_rc . ' (' . __( 'or higher', 'wordpress-beta-tester' ) . ')',
 			'release' => $exploded_version[0],
 		);
 		if ( ! $next_versions['beta'] || 'rc' === self::$options['stream-option']


### PR DESCRIPTION
Add (or higher) to the release candidate version displayed in the "Currently your site is set to update to" message.

When activating this plugin and the RC release is a version higher than 1 (e.g. 6.3-RC2) the message displayed shows

"Currently your site is set to update to version 6.2.3, 6.3-RC1, or 6.3, whichever is released first."

However, when you go to update the version available is 6.3-RC2.

This PR would change the message to include (or higher), i.e. Currently your site is set to update to version 6.2.3, 6.3-RC1 (or higher), or 6.3, whichever is released first.

See https://wordpress.org/support/topic/currently-your-site-is-set-to-update-to-message-is-incorrect/